### PR TITLE
Fix link for edit button in built site.

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -6,7 +6,7 @@ bookdown::gitbook:
         <li><a href="./">Software Analytics Survey Book</a></li>
       after: |
         <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
-    edit: https://github.com/rstudio/bookdown-demo/edit/master/%s
+    edit: https://github.com/saltudelft/software-analytics-book/edit/master/%s
     download: ["pdf", "epub"]
 bookdown::pdf_book:
   includes:


### PR DESCRIPTION
It currently links to the `bookdown-demo` repo and generates 404's.