### PR TITLE
Remove duplicate entry in book.bib

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -1837,16 +1837,6 @@ keywords = "Survey, Software testing, Industry practices, Canada"
   publisher={Springer}
 }
 
-@inproceedings{dyck2015a,
-  title = {Towards definitions for release engineering and devops},
-  author = {Dyck, Andrej and Penners, Ralf and Lichter, Horst},
-  year = {2015},
-  url = {https://www2.swc.rwth-aachen.de/docs/RELENG2015/DevOpsVsRelEng.pdf},
-  key = {dyck2015towards},
-  booktitle = {Release Engineering (RELENG), 2015 IEEE/ACM 3rd International Workshop on},
-  organization = {IEEE},
-  pages = {3--3}
-}
 @article{spinellis2018a,
   title = {The Challenges and Practices of Release Engineering},
   author = {Spinellis, Diomidis},


### PR DESCRIPTION
Also there at https://github.com/saltudelft/software-analytics-book/blob/a88fc4ddb0b71216d1238e84ca3a7edbb2c36119/book.bib#L912

Breaks current master at d29f1bd86e5862b37c4fa436d6ff81fb306f5813 (https://travis-ci.org/saltudelft/software-analytics-book/builds/439521756#L1103)

This citation was probably unused before #20 was merged.